### PR TITLE
keep resizeLock behavior consistent with slidesToScroll

### DIFF
--- a/glider.js
+++ b/glider.js
@@ -136,7 +136,7 @@
     _.track.style.width = width + 'px'
     _.trackWidth = width
 
-    _.opt.resizeLock && _.scrollTo(_.slide * _.itemWidth, 0)
+    _.opt.resizeLock && _.scrollTo(_.page * _.containerWidth, 0)
 
     if (breakpointChanged || paging) {
       _.bindArrows()

--- a/glider.js
+++ b/glider.js
@@ -366,7 +366,7 @@
 
     _.scrollTo(
       slide,
-      _.opt.duration * Math.abs(_.ele.scrollLeft - slide),
+      _.opt.duration,
       function () {
         _.updateControls()
         _.emit('animated', {
@@ -413,20 +413,20 @@
   gliderPrototype.scrollTo = function (scrollTarget, scrollDuration, callback) {
     var _ = this
 
-    var start = new Date().getTime()
+    _.animationStart = new Date().getTime();
+    _.scrollTarget = scrollTarget;
 
     var animateIndex = _.animate_id
 
     var animate = function () {
-      var now = new Date().getTime() - start
+      var now = new Date().getTime() - _.animationStart
+      var delta = (_.scrollTarget - _.ele.scrollLeft);
       _.ele.scrollLeft =
-        _.ele.scrollLeft +
-        (scrollTarget - _.ele.scrollLeft) *
-          _.opt.easing(0, now, 0, 1, scrollDuration)
-      if (now < scrollDuration && animateIndex === _.animate_id) {
+          _.opt.easing(0, now, _.ele.scrollLeft, delta, scrollDuration)
+      if (now < scrollDuration) {
         window.requestAnimationFrame(animate)
       } else {
-        _.ele.scrollLeft = scrollTarget
+        _.ele.scrollLeft = _.scrollTarget
         callback && callback.call(_)
       }
     }

--- a/glider.js
+++ b/glider.js
@@ -340,7 +340,7 @@
         if (_.opt.slidesToScroll % 1 || _.opt.slidesToShow % 1) {
           slide = _.round(_.ele.scrollLeft / _.itemWidth)
         } else {
-          slide = _.slide
+          slide = _.slide - (_.slide % _.opt.slidesToScroll)
         }
 
         if (backwards) slide -= _.opt.slidesToScroll

--- a/glider.js
+++ b/glider.js
@@ -136,7 +136,11 @@
     _.track.style.width = width + 'px'
     _.trackWidth = width
 
-    _.opt.resizeLock && _.scrollTo(_.page * _.containerWidth, 0)
+    if (! _.animationContainerWidth) {
+      _.opt.resizeLock && _.scrollTo(_.page * _.containerWidth, 0)
+    } else if (_.animationContainerWidth != _.containerWidth) {
+      _.scrollTarget = _.scrollTarget * _.containerWidth / _.animationContainerWidth;
+    }
 
     if (breakpointChanged || paging) {
       _.bindArrows()
@@ -414,6 +418,7 @@
     var _ = this
 
     _.animationStart = new Date().getTime();
+    _.animationContainerWidth = _.containerWidth;
     _.scrollTarget = scrollTarget;
 
     var animateIndex = _.animate_id
@@ -427,6 +432,7 @@
         window.requestAnimationFrame(animate)
       } else {
         _.ele.scrollLeft = _.scrollTarget
+        _.animationStart = _animationContainerWidth = null;
         callback && callback.call(_)
       }
     }


### PR DESCRIPTION
When using Glider.js to display a book, it is nice to show two slides side by side as a simulation of two book pages facing each other. However on smaller screens, it is better to show each pages independently. This can be done with the responsive attribute of Glider.js, but if the window is reduce to show only one slide, the glider is scrolled and the window is then enlarged back, we can be in a state where the right pages are now shown on the left. This patch prevents this behavior