### PR TITLE
Added "prev" and "next" for scrolItem args

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1110,7 +1110,7 @@
           </li>
           <li>
             <span class="setting-name">scrollItem(<span class="arguments">slideIndex, isActuallyDotIndex</span>)</span><br>
-            <span class="type">Arguments:</span> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a><br>
+            <span class="type">Arguments:</span> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | "prev" | "next" | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a><br>
             Scroll to any slide or page. If second argument is explicitly true, then the first argument will refer to the page to scroll to, as opposed to the slide.<br>
           </li>
           <li>


### PR DESCRIPTION
While "prev" and "next" technically are strings, I think it makes more sense to treat them as enums here.