### PR TITLE
Docs: Remove role="button" from <button> element

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -786,8 +786,8 @@
                 &lt;div&gt;your content here&lt;/div&gt;
               &lt;/div&gt;
 
-              &lt;button role="button" aria-label="Previous" class="glider-prev"&gt;&laquo;&lt;/button&gt;
-              &lt;button role="button" aria-label="Next" class="glider-next"&gt;&raquo;&lt;/button&gt;
+              &lt;button aria-label="Previous" class="glider-prev"&gt;&laquo;&lt;/button&gt;
+              &lt;button aria-label="Next" class="glider-next"&gt;&raquo;&lt;/button&gt;
               &lt;div role="tablist" class="dots"&gt;&lt;/div&gt;
             &lt;/div&gt;
           </code>


### PR DESCRIPTION
Hi 👋 

thanks so much for a great plugin.

By default `<button>` has implicit `role=button` assigned so setting it is "unnecessary and not recommended" per [specs](https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-usage-note)