### PR TITLE
Trigger an event before scrolling

### DIFF
--- a/glider.js
+++ b/glider.js
@@ -351,12 +351,11 @@
     ++_.animate_id
 
     var prevSlide = _.slide
-    var nextSlide
+    var position
 
     if (dot === true) {
-      nextSlide = slide;
-      slide = slide * _.containerWidth
-      slide = Math.round(slide / _.itemWidth) * _.itemWidth
+      slide = Math.round(slide * _.containerWidth / _.itemWidth)
+      position = slide * _.itemWidth
     } else {
       if (typeof slide === 'string') {
         var backwards = slide === 'prev'
@@ -383,17 +382,17 @@
         }
       }
 
-      slide = nextSlide = Math.max(Math.min(slide, _.slides.length), 0)
+      slide = Math.max(Math.min(slide, _.slides.length), 0)
 
       _.slide = slide
-      slide = _.itemWidth * slide
+      position = _.itemWidth * slide
     }
 
-    _.emit('scroll-item', {prevSlide, nextSlide});
+    _.emit('scroll-item', {prevSlide, slide});
 
     _.scrollTo(
-      slide,
-      _.opt.duration * Math.abs(_.ele.scrollLeft - slide),
+      position,
+      _.opt.duration * Math.abs(_.ele.scrollLeft - position),
       function () {
         _.updateControls()
         _.emit('animated', {

--- a/glider.js
+++ b/glider.js
@@ -350,7 +350,11 @@
     var originalSlide = slide
     ++_.animate_id
 
+    var prevSlide = _.slide
+    var nextSlide
+
     if (dot === true) {
+      nextSlide = slide;
       slide = slide * _.containerWidth
       slide = Math.round(slide / _.itemWidth) * _.itemWidth
     } else {
@@ -379,11 +383,13 @@
         }
       }
 
-      slide = Math.max(Math.min(slide, _.slides.length), 0)
+      slide = nextSlide = Math.max(Math.min(slide, _.slides.length), 0)
 
       _.slide = slide
       slide = _.itemWidth * slide
     }
+
+    _.emit('scroll-item', {prevSlide, nextSlide});
 
     _.scrollTo(
       slide,


### PR DESCRIPTION
Sometimes there is a need to know which slide is going to be the next one, _before_ the scroll animation occurs.

Currently, the `glider-slide-hidden` event triggers before the glider is scrolled, but it doesn't say which slide is next. And once `glider-slide-visible` triggers, it's already too late.

This is useful when syncing Glider with someting else. Currently if you hide someting on `glider-slide-hidden` and show something else on `glider-slide-visible`, then you'd get a gap between one and the other.