### PR TITLE
Remove track element during destroy only if it was created by glider

### DIFF
--- a/glider.js
+++ b/glider.js
@@ -566,8 +566,10 @@
         /^glider/.test(className) && ele.classList.remove(className)
       })
     }
-    // remove track
-    replace.children[0].outerHTML = replace.children[0].innerHTML
+    // remove track if it was created by glider
+    if (!_.opt.skipTrack) {
+      replace.children[0].outerHTML = replace.children[0].innerHTML
+    }
     clear(replace);
     [].forEach.call(replace.getElementsByTagName('*'), clear)
     _.ele.parentNode.replaceChild(replace, _.ele)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glider-js",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "A fast, lightweight carousel alternative",
   "main": "glider.js",
   "directories": {


### PR DESCRIPTION
It's not necessary to remove the track element during destroy if it was not created by glider but by the user (using skipTrack: true). Additionally, the statement assigning innerHTML to outerHTML causes problems with Content Security Policy without 'unsafe-inline' keyword or similar workaround.