### PR TITLE
Add resize observer to refresh when visibilty changes

### DIFF
--- a/glider.js
+++ b/glider.js
@@ -94,6 +94,21 @@
     _.event(_window, 'add', {
       resize: _.resize
     })
+    
+    // reset breakpoint and refresh on show / hide
+    if (ResizeObserver) {
+      _.resizeObserver = new ResizeObserver(function (entries) {
+        [].forEach.call(entries, function(__) {
+          var _ = __.target._glider;
+          if (_ && _.ele.clientWidth !== _.containerWidth && (_.ele.clientWidth == 0 || _.containerWidth == 0)) {
+            _.breakpoint = 0;
+            _.refresh(false);
+          }
+        });
+      });
+                
+      _.resizeObserver.observe(_.ele);
+    }
   })
 
   var gliderPrototype = Glider.prototype


### PR DESCRIPTION
In cases were the gilder starts hidden and is shown by user action, the dots will not recalculate and arrows will not function if slidesToShow is 'auto' as that value will calculate to zero.
This might happen if the glider is placed inside a drawer or accordion component.

If the glider is set to be responsive, a ResizeObserver can be used to detect show / hide, reset the breakpoint, and refresh the glider.

Fix for #276
This is low priority as code can be added outside glider.js to workaround the issue